### PR TITLE
ENH: add `raise_if_err` alias for `expect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ```python
-  Result.raise_if_err(
-    self,
-    msg: str,
-    exc_cls: t.Type[Exception] = RuntimeError
-  ) -> T
-  ```
-
-  added. Semantically friendly alias for `Result.expect`.
-
-- ```python
-  Option.raise_if_err(
-    self,
-    msg: str,
-    exc_cls: t.Type[Exception] = RuntimeError
-  ) -> T
-  ```
-
-  added. Semantically friendly alias for `Option.expect`.
+- `Result.raise_if_err(self, msg: str, exc_cls: t.Type[Exception] = RuntimeError) -> T`
+  added as a semantically friendly alias for `Result.expect`.
+- `Option.raise_if_err(self, msg: str, exc_cls: t.Type[Exception] = RuntimeError) -> T`
+  added as a semantically friendly alias for `Option.expect`.
 
 ## [1.1.0] - 2019-01-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ```python
+  Result.raise_if_err(
+    self,
+    msg: str,
+    exc_cls: t.Type[Exception] = RuntimeError
+  ) -> T
+  ```
+
+  added. Semantically friendly alias for `Result.expect`.
+
+- ```python
+  Option.raise_if_err(
+    self,
+    msg: str,
+    exc_cls: t.Type[Exception] = RuntimeError
+  ) -> T
+  ```
+
+  added. Semantically friendly alias for `Option.expect`.
+
 ## [1.1.0] - 2019-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ with us, please check out [our careers page](https://hellobestow.com/careers/)!
         - [Result.err](#resulterr)
         - [Result.ok](#resultok)
         - [Result.expect](#resultexpect)
+        - [Result.raise_if_err](#resultraise_if_err)
         - [Result.expect_err](#resultexpect_err)
         - [Result.is_err](#resultis_err)
         - [Result.is_ok](#resultis_ok)
@@ -140,6 +141,7 @@ with us, please check out [our careers page](https://hellobestow.com/careers/)!
         - [Option.flatmap](#optionflatmap)
         - [Option.or_else](#optionor_else)
         - [Option.expect](#optionexpect)
+        - [Option.raise_if_err](#optionraise_if_err)
         - [Option.filter](#optionfilter)
         - [Option.is_nothing](#optionis_nothing)
         - [Option.is_some](#optionis_some)
@@ -430,7 +432,7 @@ assert Ok(5).or_(Err(1)) == Ok(5)
 If this Result is `Ok`, call the provided function with the wrapped value of
 this Result and return the Result of that function. This allows easily
 chaining multiple Result-generating calls together to yield a final
-Result. This method is an alias of [`flatmap`](#resultflatmap)
+Result. This method is an alias of [`Result.flatmap`](#resultflatmap)
 
 Example:
 
@@ -446,7 +448,7 @@ assert Err(1).and_then(lambda val: Ok(val + 1)) == Err(1)
 If this Result is `Ok`, call the provided function with the wrapped value of
 this Result and return the Result of that function. This allows easily
 chaining multiple Result-generating calls together to yield a final
-Result. This method is an alias of [`and_then`](#result.and_then)
+Result. This method is an alias of [`Result.and_then`](#result.and_then)
 
 Example:
 
@@ -505,7 +507,8 @@ assert Err(1).ok() == Nothing()
 Return the wrapped value if this Result is `Ok`. Otherwise, raise an error,
 instantiated with the provided message and the stringified error value.
 By default, a `RuntimeError` is raised, but an alternative error may be
-provided using the `exc_cls` keyword argument.
+provided using the `exc_cls` keyword argument. This method is an alias for
+[`Result.raise_if_err`](#resultraise_if_err).
 
 Example:
 
@@ -517,6 +520,28 @@ with pytest.raises(RuntimeError) as exc:
     assert str(exc.value) == "Bad value: 5"
 
 assert Ok(1).expect("Bad value") == 1
+```
+
+##### Result.raise_if_err
+
+`Result.raise_if_err(self, msg: str, exc_cls: t.Type[Exception] = RuntimeError) -> T`
+
+Return the wrapped value if this Result is `Ok`. Otherwise, raise an error,
+instantiated with the provided message and the stringified error value.
+By default, a `RuntimeError` is raised, but an alternative error may be
+provided using the `exc_cls` keyword argument. This method is an alias for
+[`Result.expect`](#resultexpect).
+
+Example:
+
+```py
+import pytest
+
+with pytest.raises(RuntimeError) as exc:
+    Err(5).raise_if_err("Bad value")
+    assert str(exc.value) == "Bad value: 5"
+
+assert Ok(1).raise_if_err("Bad value") == 1
 ```
 
 ##### Result.expect_err
@@ -979,7 +1004,7 @@ assert Some(1).or_else(lambda: Some(2)) == Some(1)
 If this Option is `Some`, return the wrapped value. Otherwise, if this
 Option is `Nothing`, raise an error instantiated with the provided message.
 By default, a `RuntimeError` is raised, but a custom exception class may be
-provided via the `exc_cls` keyword argument.
+provided via the `exc_cls` keyword argument. This method is an alias of [`Option.raise_if_err`](#optionraise_if_err).
 
 Example:
 
@@ -991,6 +1016,27 @@ with pytest.raises(RuntimeError) as exc:
     assert str(exc.value) == "Nothing here"
 
 assert Some(1).expect("Nothing here") == 1
+```
+
+##### Option.raise_if_err
+
+`Option.raise_if_err(self, msg: str, exc_cls: t.Type[Exception] = RuntimeError) -> T`
+
+If this Option is `Some`, return the wrapped value. Otherwise, if this
+Option is `Nothing`, raise an error instantiated with the provided message.
+By default, a `RuntimeError` is raised, but a custom exception class may be
+provided via the `exc_cls` keyword argument. This method is an alias of [`Option.expect`](#optionexpect).
+
+Example:
+
+```py
+import pytest
+
+with pytest.raises(RuntimeError) as exc:
+    Nothing().raise_if_err("Nothing here")
+    assert str(exc.value) == "Nothing here"
+
+assert Some(1).raise_if_err("Nothing here") == 1
 ```
 
 ##### Option.filter

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ assert Err(1).and_then(lambda val: Ok(val + 1)) == Err(1)
 If this Result is `Ok`, call the provided function with the wrapped value of
 this Result and return the Result of that function. This allows easily
 chaining multiple Result-generating calls together to yield a final
-Result. This method is an alias of [`Result.and_then`](#result.and_then)
+Result. This method is an alias of [`Result.and_then`](#resultand_then)
 
 Example:
 
@@ -1004,7 +1004,8 @@ assert Some(1).or_else(lambda: Some(2)) == Some(1)
 If this Option is `Some`, return the wrapped value. Otherwise, if this
 Option is `Nothing`, raise an error instantiated with the provided message.
 By default, a `RuntimeError` is raised, but a custom exception class may be
-provided via the `exc_cls` keyword argument. This method is an alias of [`Option.raise_if_err`](#optionraise_if_err).
+provided via the `exc_cls` keyword argument. This method is an alias 
+of [`Option.raise_if_err`](#optionraise_if_err).
 
 Example:
 
@@ -1025,7 +1026,8 @@ assert Some(1).expect("Nothing here") == 1
 If this Option is `Some`, return the wrapped value. Otherwise, if this
 Option is `Nothing`, raise an error instantiated with the provided message.
 By default, a `RuntimeError` is raised, but a custom exception class may be
-provided via the `exc_cls` keyword argument. This method is an alias of [`Option.expect`](#optionexpect).
+provided via the `exc_cls` keyword argument. This method is an alias 
+of [`Option.expect`](#optionexpect).
 
 Example:
 

--- a/src/safetywrap/_impl.py
+++ b/src/safetywrap/_impl.py
@@ -186,7 +186,7 @@ class Ok(Result[T, E]):
 
         Alias for `Ok.expect`.
         """
-        return self.expect(msg, exc_cls)
+        return self.expect(msg, exc_cls=exc_cls)
 
     def expect_err(
         self, msg: str, exc_cls: t.Type[Exception] = RuntimeError

--- a/src/safetywrap/_impl.py
+++ b/src/safetywrap/_impl.py
@@ -452,6 +452,18 @@ class Some(Option[T]):
         """
         return self._value
 
+    def raise_if_err(
+        self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
+    ) -> T:
+        """Unwrap and yield a `Some`, or throw an exception if `Nothing`.
+
+        The exception class may be specified with the `exc_cls` keyword
+        argument.
+
+        Alias of `Some.expect`.
+        """
+        return self.expect(msg, exc_cls)
+
     def filter(self, predicate: t.Callable[[T], bool]) -> Option[T]:
         """Return `Nothing`, or an option determined by the predicate.
 
@@ -601,6 +613,18 @@ class Nothing(Option[T]):
         argument.
         """
         raise exc_cls(msg)
+
+    def raise_if_err(
+        self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
+    ) -> T:
+        """Unwrap and yield a `Some`, or throw an exception if `Nothing`.
+
+        The exception class may be specified with the `exc_cls` keyword
+        argument.
+
+        Alias of `Nothing.expect`.
+        """
+        return self.expect(msg, exc_cls)
 
     def filter(self, predicate: t.Callable[[T], bool]) -> Option[T]:
         """Return `Nothing`, or an option determined by the predicate.

--- a/src/safetywrap/_impl.py
+++ b/src/safetywrap/_impl.py
@@ -176,6 +176,18 @@ class Ok(Result[T, E]):
         """
         return self._value
 
+    def raise_if_err(
+        self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
+    ) -> T:
+        """Return `Ok` value or raise an error with the specified message.
+
+        The raised exception class may be specified with the `exc_cls`
+        keyword argument.
+
+        Alias for `Ok.expect`.
+        """
+        return self.expect(msg, exc_cls)
+
     def expect_err(
         self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
     ) -> E:
@@ -304,6 +316,18 @@ class Err(Result[T, E]):
         keyword argument.
         """
         raise exc_cls(f"{msg}: {self._value}")
+
+    def raise_if_err(
+        self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
+    ) -> T:
+        """Return `Ok` value or raise an error with the specified message.
+
+        The raised exception class may be specified with the `exc_cls`
+        keyword argument.
+
+        Alias for `Err.expect`.
+        """
+        return self.expect(msg, exc_cls)
 
     def expect_err(
         self, msg: str, exc_cls: t.Type[Exception] = RuntimeError

--- a/src/safetywrap/_impl.py
+++ b/src/safetywrap/_impl.py
@@ -327,7 +327,7 @@ class Err(Result[T, E]):
 
         Alias for `Err.expect`.
         """
-        return self.expect(msg, exc_cls)
+        return self.expect(msg, exc_cls=exc_cls)
 
     def expect_err(
         self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
@@ -462,7 +462,7 @@ class Some(Option[T]):
 
         Alias of `Some.expect`.
         """
-        return self.expect(msg, exc_cls)
+        return self.expect(msg, exc_cls=exc_cls)
 
     def filter(self, predicate: t.Callable[[T], bool]) -> Option[T]:
         """Return `Nothing`, or an option determined by the predicate.
@@ -624,7 +624,7 @@ class Nothing(Option[T]):
 
         Alias of `Nothing.expect`.
         """
-        return self.expect(msg, exc_cls)
+        return self.expect(msg, exc_cls=exc_cls)
 
     def filter(self, predicate: t.Callable[[T], bool]) -> Option[T]:
         """Return `Nothing`, or an option determined by the predicate.

--- a/src/safetywrap/_interface.py
+++ b/src/safetywrap/_interface.py
@@ -279,6 +279,18 @@ class _Option(t.Generic[T]):
         """
         raise NotImplementedError
 
+    def raise_if_err(
+        self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
+    ) -> T:
+        """Unwrap and yield a `Some`, or throw an exception if `Nothing`.
+
+        The exception class may be specified with the `exc_cls` keyword
+        argument.
+
+        Alias of `expect`.
+        """
+        raise NotImplementedError
+
     def filter(self, predicate: t.Callable[[T], bool]) -> "Option[T]":
         """Return `Nothing`, or an option determined by the predicate.
 

--- a/src/safetywrap/_interface.py
+++ b/src/safetywrap/_interface.py
@@ -121,6 +121,21 @@ class _Result(t.Generic[T, E]):
         """
         raise NotImplementedError
 
+    def raise_if_err(
+        self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
+    ) -> T:
+        """Return `Ok` value or raise an error with the specified message.
+
+        The raised exception class may be specified with the `exc_cls`
+        keyword argument.
+
+        The underlying error will be stringified and appended to the
+        provided message.
+
+        Alias of `expect`.
+        """
+        raise NotImplementedError
+
     def expect_err(
         self, msg: str, exc_cls: t.Type[Exception] = RuntimeError
     ) -> E:

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -162,9 +162,25 @@ class TestOption:
 
         assert msg in str(exc_info.value)
 
+    @pytest.mark.parametrize("exc_cls", (None, IOError))
+    def test_raise_if_err_raising(self, exc_cls: t.Type[Exception]) -> None:
+        """Can specify exception msg/cls if value is not Some()."""
+        exp_exc = exc_cls if exc_cls else RuntimeError
+        kwargs = {"exc_cls": exc_cls} if exc_cls else {}
+        msg = "not what I expected"
+
+        with pytest.raises(exp_exc) as exc_info:
+            Nothing().raise_if_err(msg, **kwargs)
+
+        assert msg in str(exc_info.value)
+
     def test_expect_not_raising(self) -> None:
         """Expecting on a Some() returns the value."""
         assert Some("hello").expect("not what I expected") == "hello"
+
+    def test_raise_if_err_not_raising(self) -> None:
+        """raise_if_err on a Some() returns the value."""
+        assert Some("hello").raise_if_err("not what I expected") == "hello"
 
     @pytest.mark.parametrize(
         "start, exp",

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -212,6 +212,7 @@ class TestResult:
             Err(2).raise_if_err(msg, **kwargs)
 
         assert msg in str(exc_info.value)
+        assert "2" in str(exc_info.value)
 
     def test_expect_ok(self) -> None:
         """Expecting an Ok() value returns the value."""

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -201,9 +201,25 @@ class TestResult:
 
         assert msg in str(exc_info.value)
 
+    @pytest.mark.parametrize("exc_cls", (None, IOError))
+    def test_raise_if_err_raising(self, exc_cls: t.Type[Exception]) -> None:
+        """Test raise_if_err for Err() values."""
+        exp_exc = exc_cls if exc_cls else RuntimeError
+        kwargs = {"exc_cls": exc_cls} if exc_cls else {}
+        msg = "not what I expected"
+
+        with pytest.raises(exp_exc) as exc_info:
+            Err(2).raise_if_err(msg, **kwargs)
+
+        assert msg in str(exc_info.value)
+
     def test_expect_ok(self) -> None:
         """Expecting an Ok() value returns the value."""
         assert Ok(2).expect("err") == 2
+
+    def test_raise_if_err_ok(self) -> None:
+        """Raise_if_err returns the value when given an Ok() value."""
+        assert Ok(2).raise_if_err("err") == 2
 
     @pytest.mark.parametrize("exc_cls", (None, IOError))
     def test_expect_err_raising(self, exc_cls: t.Type[Exception]) -> None:

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -194,25 +194,28 @@ class TestResult:
         """Test expecting a value to be Ok()."""
         exp_exc = exc_cls if exc_cls else RuntimeError
         kwargs = {"exc_cls": exc_cls} if exc_cls else {}
+        input_val = 2
         msg = "not what I expected"
 
         with pytest.raises(exp_exc) as exc_info:
-            Err(2).expect(msg, **kwargs)
+            Err(input_val).expect(msg, **kwargs)
 
         assert msg in str(exc_info.value)
+        assert str(input_val) in str(exc_info.value)
 
     @pytest.mark.parametrize("exc_cls", (None, IOError))
     def test_raise_if_err_raising(self, exc_cls: t.Type[Exception]) -> None:
         """Test raise_if_err for Err() values."""
         exp_exc = exc_cls if exc_cls else RuntimeError
         kwargs = {"exc_cls": exc_cls} if exc_cls else {}
+        input_val = 2
         msg = "not what I expected"
 
         with pytest.raises(exp_exc) as exc_info:
-            Err(2).raise_if_err(msg, **kwargs)
+            Err(input_val).raise_if_err(msg, **kwargs)
 
         assert msg in str(exc_info.value)
-        assert "2" in str(exc_info.value)
+        assert str(input_val) in str(exc_info.value)
 
     def test_expect_ok(self) -> None:
         """Expecting an Ok() value returns the value."""


### PR DESCRIPTION
`Option.expect` and `Result.expect` take their names from their respective analogs in Rust. That said, the "expect" name [isn't particularly descriptive of its associated method behavior](https://old.reddit.com/r/rust/comments/4m00lx/method_names_on_result_and_option/). This pull request adds a `raise_if_err` method to the `Option` and `Result` classes to serve as a semantically clearer alias for `expect`.